### PR TITLE
Fix permission error preventing upload of large pastes.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,5 +7,6 @@ if [ ! -f /privatebin/cfg/conf.ini ]; then
 	cp /privatebin/conf.ini.sample /privatebin/cfg/conf.ini
 fi
 
-chown -R privatebin:privatebin /privatebin /var/run/php-fpm.sock /var/lib/nginx /tmp
+chown -R privatebin:privatebin /privatebin /var/run/php-fpm.sock /var/lib/nginx /tmp /var/tmp/nginx
 supervisord -c /usr/local/etc/supervisord.conf
+


### PR DESCRIPTION
When uploading large pastes (larger than the nginx buffer size), the temp directory `/var/tmp/nginx` is used. Because nginx is running as the `privatebin` user, but this temp directory is still owned by the `nginx` user, large uploads fail. There are several possible fixes, including increasing the nginx buffer size, changing its temp directory to, e.g, `/tmp`, or updating the permissions on `/var/tmp/nginx/`. This commit takes the latter approach. More details can be found on [this GitHub issue](https://github.com/dockerfile/nginx/issues/4).