### PR TITLE
Making the PrivateBin container image more robust

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Docs
+README.md
+LICENSE
+
+# build
+build.sh
+buildNoCache.sh
+
+# Git
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,9 @@ RUN apk -U add \
     php7-gd \
     php7-mcrypt \
     php7-json \
-    php7-zlib \
     php7-pdo \
     php7-pdo_mysql \
     supervisor \
-    tini \
     ca-certificates \
     tar \
  && mkdir privatebin && cd privatebin \
@@ -32,10 +30,9 @@ COPY files/php-fpm.conf /etc/php7/php-fpm.conf
 COPY files/supervisord.conf /usr/local/etc/supervisord.conf
 COPY entrypoint.sh /
 
-RUN chmod +x /entrypoint.sh
-
-VOLUME [ "/privatebin/data", "/privatebin/cfg" ]
+# mark dirs as volumes that need to be writable, allows running the container --read-only
+VOLUME [ "/privatebin/data", "/privatebin/cfg", "/etc", "/tmp", "/var/tmp", "/run", "/var/log" ]
 
 EXPOSE 80
 LABEL description "PrivateBin is a minimalist, open source online pastebin where the server has zero knowledge of pasted data."
-CMD ["/sbin/tini","--","/entrypoint.sh"]
+CMD ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,20 +10,31 @@ RUN apk -U add \
     nginx \
     php7-fpm \
     php7-gd \
-    php7-mcrypt \
     php7-json \
     php7-pdo \
     php7-pdo_mysql \
     supervisor \
     ca-certificates \
     tar \
- && mkdir privatebin && cd privatebin \
- && curl -L -o privatebin.tar.gz https://github.com/PrivateBin/PrivateBin/archive/$VERSION.tar.gz \
- && tar xvzf privatebin.tar.gz --strip 1 \
- && rm privatebin.tar.gz \
- && mv cfg/conf.sample.php /privatebin \
- && apk del tar ca-certificates curl libcurl \
- && rm -f /var/cache/apk/*
+    gnupg \
+ && mkdir -p privatebin/data \
+ && export GNUPGHOME="$(mktemp -d)" \
+ && gpg2 --list-public-keys || /bin/true \
+ && curl -s https://privatebin.info/key/rugk.asc | gpg2 --import - \
+ && curl -Lso privatebin.tar.gz.asc https://github.com/PrivateBin/PrivateBin/releases/download/$VERSION/PrivateBin-$VERSION.tar.gz.asc \
+ && curl -Lso privatebin.tar.gz https://github.com/PrivateBin/PrivateBin/archive/$VERSION.tar.gz \
+ && gpg2 --verify privatebin.tar.gz.asc \
+ && rm -rf "$GNUPGHOME" /var/www/* \
+ && cd /var/www \
+ && tar -xzf /privatebin.tar.gz --strip 1 \
+ && mv cfg/conf.sample.php /privatebin/ \
+ && mv cfg /privatebin/ \
+ && mv lib /privatebin \
+ && mv tpl /privatebin \
+ && mv vendor /privatebin \
+ && sed -i "s#define('PATH', '');#define('PATH', '/privatebin/');#" index.php \
+ && apk del tar ca-certificates curl gnupg \
+ && rm -f /privatebin.tar.gz* *.md /var/cache/apk/*
 
 COPY files/nginx.conf /etc/nginx/nginx.conf
 COPY files/php-fpm.conf /etc/php7/php-fpm.conf

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A tiny image running [alpine](https://github.com/gliderlabs/docker-alpine) Linux
 ## Usage
 
 	docker run --restart=always -d \
+		--read-only
 		-p 0.0.0.0:80:80 \
 		--hostname=privatebin \
 		--name=privatebin \
@@ -13,7 +14,7 @@ A tiny image running [alpine](https://github.com/gliderlabs/docker-alpine) Linux
 		-v /<host_cfg_directory>:/privatebin/cfg \
 		jgeusebroek/privatebin
 
-On first run it will copy the sample config file if there isn't a config file already.
+On first run it will copy the sample config file, if there isn't a config file already.
 
 ## Optional environment variables
 

--- a/buildNoCache.sh
+++ b/buildNoCache.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker build --rm --pull --no-cache -t jgeusebroek/zerobin .
+docker build --rm --pull --no-cache -t jgeusebroek/privatebin .

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-addgroup -g ${GID} privatebin && adduser -h /privatebin -s /bin/sh -D -G privatebin -u ${UID} privatebin
-touch /var/run/php-fpm.sock
+addgroup -g ${GID} privatebin && \
+adduser -h /privatebin -H -s /bin/sh -D -G privatebin -u ${UID} privatebin
 
 if [ ! -f /privatebin/cfg/conf.php ]; then
 	cp /privatebin/conf.sample.php /privatebin/cfg/conf.php
 fi
 
-chown -R privatebin:privatebin /privatebin /var/run/php-fpm.sock /var/lib/nginx /tmp /var/tmp/nginx
+chown -R privatebin:privatebin /privatebin/data
 supervisord -c /usr/local/etc/supervisord.conf

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -12,8 +12,8 @@ http {
     include /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    access_log off;
-    error_log /var/log/nginx/error.log error;
+    access_log /dev/stdout;
+    error_log /dev/stderr error;
 
     sendfile on;
     keepalive_timeout 15;
@@ -47,14 +47,14 @@ http {
         image/svg+xml;
 
     server {
-    	listen 80;
-    	root /privatebin;
-    	index index.php index.html;
+        listen 80;
+        root /privatebin;
+        index index.php index.html;
 
-    	location ~* \.(jpg|jpeg|gif|css|png|js|map|woff|woff2|ttf|svg|eot)$ {
-    		expires 30d;
-    		access_log off;
-	}
+        location ~* \.(jpg|jpeg|gif|css|png|js|map|woff|woff2|ttf|svg|eot)$ {
+            expires 30d;
+            access_log off;
+        }
 
         location ~ ^/(data|cfg|tmp) {
             deny all;
@@ -68,17 +68,15 @@ http {
             deny all;
         }
 
-    	location / {
-        	try_files $uri $uri/ /index.php;
-    	}
+        location / {
+            try_files $uri $uri/ /index.php;
+        }
 
-	location ~ \.php$ {
-    		fastcgi_index index.php;
-    		fastcgi_pass unix:/var/run/php-fpm.sock;
-    		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    		include /etc/nginx/fastcgi_params;
-	}
-
+        location ~ \.php$ {
+            fastcgi_index index.php;
+            fastcgi_pass unix:/var/run/php-fpm.sock;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            include /etc/nginx/fastcgi_params;
+        }
     }
-
 }

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -48,7 +48,7 @@ http {
 
     server {
         listen 80;
-        root /privatebin;
+        root /var/www;
         index index.php index.html;
 
         location ~* \.(jpg|jpeg|gif|css|png|js|map|woff|woff2|ttf|svg|eot)$ {

--- a/files/php-fpm.conf
+++ b/files/php-fpm.conf
@@ -11,4 +11,4 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
-chdir = /
+chdir = /var/www

--- a/files/php-fpm.conf
+++ b/files/php-fpm.conf
@@ -1,3 +1,5 @@
+[global]
+daemonize = no
 [www]
 user = privatebin
 group = privatebin

--- a/files/supervisord.conf
+++ b/files/supervisord.conf
@@ -1,8 +1,19 @@
 [supervisord]
 nodaemon=true
+pidfile=/var/run/supervisord.pid
+logfile=/var/log/supervisord.log
 
 [program:php-fpm]
-command=php-fpm7 --nodaemonize
+command=php-fpm7
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 
 [program:nginx]
 command=nginx
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+


### PR DESCRIPTION
Hello Jeroen,

Please find attached some changes for your docker image of PrivateBin, the main goal being to implement our recommendations for installing our software. The key changes and reasoning for them:
- made the image support read-only operation - this is optional, but prevents exploits to change the scripts or binaries in the container
- adding a gpg signature check for the PrivateBin archive - while it is downloaded over HTTPS, this guarantees the archive hasn't been tampered with after @rugk signed the release archive.
- splitting the installation between web root and libraries / data - further reduces any risk of exposing unparsed PHP files or even data
- configured all logs of nginx & php-fpm to be forwarded to docker logs - simplifies both debugging and central log collection (you just configure docker to forward your logs, instead of configuring log collection per container image)
- added a .dockerignore - reducing the docker build context by a few kBs
- simplyfied the entrypoint script, ensuring it works with just busybox, removing need for tini shell

Let me know if you'd like to change any of this to align with your docker or shell scripting standards.

Kind regards,
El RIDO