### PR TITLE
allow pastes larger then a few kB, addressing supervisord warning

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,5 +7,5 @@ if [ ! -f /privatebin/cfg/conf.php ]; then
 	cp /privatebin/conf.sample.php /privatebin/cfg/conf.php
 fi
 
-chown -R privatebin:privatebin /privatebin/data
+chown -R privatebin:privatebin /privatebin/data /var/tmp/nginx
 supervisord -c /usr/local/etc/supervisord.conf

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -22,6 +22,7 @@ http {
     tcp_nopush on;
     tcp_nodelay off;
     server_tokens off;
+    client_max_body_size 10M;
 
     gzip on;
     gzip_comp_level 5;

--- a/files/supervisord.conf
+++ b/files/supervisord.conf
@@ -1,4 +1,5 @@
 [supervisord]
+user=root
 nodaemon=true
 pidfile=/var/run/supervisord.pid
 logfile=/var/log/supervisord.log


### PR DESCRIPTION
Over in the PrivateBin project we had an [issue reported related to this docker image](https://github.com/PrivateBin/PrivateBin/issues/368). Since I notice that it didn't get reported here as I suggested and I found a solution, I thought I'll do the PR for it.

The following 3 changes are included:

1. The folder /var/tmp/nginx gets owned by the privatebin user, to make it writeable to the nginx process, required for larger request bodies that get cached here. (still works as a --read-only image)
2. In testing I noticed that nginx by default only allows a `client_max_body_size` of 1 MiB. Since PB by default accepts 2 MiB pastes, I increased it to 10 MiB in nginx, so that pasted content up to that size gets a descriptive error message from PB. Content larger then that results in a generic error message (in docker logs you will then see an `[error] client intended to send too large body`)
3. Finally I noticed a warning of supervisord, which I also addressed (`CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.`) - supervisord runs as root and starts nginx and php-fpm as such, but both daemons drop their privilege after binding ports to the user privatebin.