### PR TITLE
Allow users to add custom http-level nginx config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN apk -U add \
  && mv vendor /privatebin \
  && sed -i "s#define('PATH', '');#define('PATH', '/privatebin/');#" index.php \
  && apk del tar ca-certificates curl gnupg \
- && rm -f /privatebin.tar.gz* *.md /var/cache/apk/*
+ && rm -f /privatebin.tar.gz* *.md /var/cache/apk/* \
+ && rm /etc/nginx/conf.d/default.conf
 
 COPY files/nginx.conf /etc/nginx/nginx.conf
 COPY files/php-fpm.conf /etc/php7/php-fpm.conf

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -47,6 +47,8 @@ http {
         font/opentype
         image/svg+xml;
 
+    include /etc/nginx/conf.d/*.conf;
+
     server {
         listen 80;
         root /var/www;


### PR DESCRIPTION
This is particularly useful if you need to add realip config, to ensure Privatebin's IP-based rate limiting works correctly.